### PR TITLE
IL-143 add-userid-to-logs

### DIFF
--- a/src/main/java/com/zufar/onlinestore/security/configuration/UserIdMdcFilter.java
+++ b/src/main/java/com/zufar/onlinestore/security/configuration/UserIdMdcFilter.java
@@ -1,0 +1,46 @@
+package com.zufar.onlinestore.security.configuration;
+
+import com.zufar.onlinestore.security.api.SecurityPrincipalProvider;
+import com.zufar.onlinestore.security.jwt.filter.JwtAuthenticationProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Enriches MDC with user.userId.
+ */
+@Order
+@Component
+@AllArgsConstructor
+public class UserIdMdcFilter extends OncePerRequestFilter {
+
+    private final SecurityPrincipalProvider securityPrincipalProvider;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    private static final String MDC_USER_ID_KEY2VALUE = "user.id.key2value";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        var isUserPresent = jwtAuthenticationProvider.get(request).isPresent();
+        if (isUserPresent) {
+            var userId = securityPrincipalProvider.getUserId();
+            MDC.put(MDC_USER_ID_KEY2VALUE, "USERID:" + userId.toString());
+        } else {
+            MDC.remove(MDC_USER_ID_KEY2VALUE);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
    <!--  CONSOLE LOGGING CONFIGURATION  -->
     <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d [%thread] %-5level %-50logger{40} - %msg%n</pattern>
+            <pattern>%d [%thread] %-5level %-50logger{40} %X{user.id.key2value} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Changes:
 - Added MDC key user.id.key2value with USERID:UUID 
 - Updated logger pattern

Log example:
`2023-10-29 17:28:47,559 [http-nio-8083-exec-1] INFO  c.z.o.product.endpoint.ProductsEndpoint            USERID:66666666-6666-6666-6666-666666666666 - Products were retrieved successfully with these pagination and sorting attributes: page - 0, size - 50, sort_attribute - name, sort_direction - desc`
